### PR TITLE
Fix .swcrc resolution for absolute paths

### DIFF
--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -111,10 +111,10 @@ impl Compiler {
                             return Ok(arc);
                         }
 
-                        parent = dir.parent();
-                        if parent == Some(&*root) && *root_mode == RootMode::Root {
+                        if dir == root && *root_mode == RootMode::Root {
                             break;
                         }
+                        parent = dir.parent();
                     }
                 }
                 _ => {}


### PR DESCRIPTION
Currently, this project will not find your `.swcrc` file if it is in your current working directory, and you use an absolute path.

# Steps to reproduce

```bash
$ mkdir -p swc-test/foo
$ cd swc-test
$ npm i swc
$ echo "const x = <Foo></Foo>;" > foo/bar.js
$ npx swc foo/bar.js # at this point, we have not configured swc to use JSX, so this is expected.
error: Unexpected token Some(BinOp(Lt))
 --> foo/bar.js:1:11
  |
1 | const x = <Foo></Foo>;
  |           ^

fatal runtime error: failed to initiate panic, error 5
$ echo '{"jsc": {"parser": {"jsx": true}}}' > .swcrc
$ npx swc foo/bar.js # Now swc is picking up our .swcrc file with the JSX config, so it works
var x = React.createElement(Foo, null);
$ npx swc $(pwd)/foo/bar.js # swc is no longer finding our .swcrc file
error: Unexpected token Some(BinOp(Lt))
 --> foo/bar.js:1:11
  |
1 | const x = <Foo></Foo>;
  |           ^

fatal runtime error: failed to initiate panic, error 5
```

If we look at the file resolution code, this makes sense: we break out of the loop if the current directory's parent is the same as the root, after failing to find the `.swcrc` file in the current directory. To lay out the steps that swc is taking for the above example: 

1. Search the `$(pwd)/foo` directory for the `.swcrc` file
1. Set the `parent` variable to `$(pwd)`
1. Check if `parent` is equal to the `root` (in this case it's `$(pwd)`), they are
1. Break out of the loop before checking `$(pwd)`

My changes make sure that swc will check the `root` folder as well, by checking if the current directory is the same as the root, only after verifying that the `.swcrc` file is not in the current directory.