### PR TITLE
Add engines field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "lib/index.js",
   "author": "강동윤 <kdy1@outlook.kr>",
   "license": "MIT",
+  "engines": {
+    "node": ">=0.8 <0.12"
+  },
   "dependencies": {
     "mkdirp": "^0.5.1",
     "neon-cli": "^0.2.0",


### PR DESCRIPTION
Trying to install @swc/core on a machine running Node 12 fails with `install fails with missing `https://github.com/swc-project/node-swc/releases/download/v1.0.45/darwin-x64-72.node`. The install script then prints instructions on fixing proxies which does not apply.

Adding the `engines` range to package.json will provide users with a hint on what has gone wrong. Alternatively this could be done in the install script itself, but then the supported range has to be maintained in code.