### PR TITLE
Enable ThinLTO by default, Use monolithic LTO only on Linux

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -27,5 +27,5 @@ serde = { version = "1", features = ["derive"] }
 lto = true
 
 [profile.release]
-# lto = true
+lto = "thin"
 codegen-units = 1

--- a/scripts/ci/linux/build.sh
+++ b/scripts/ci/linux/build.sh
@@ -9,7 +9,7 @@
 ####################
 set -e
 
-sed "s/# lto/lto/" native/Cargo.toml -i
+sed 's|lto = "thin"|lto = true|' native/Cargo.toml -i
 
 # (cd native && cargo build --release --verbose)
 echo 'Installing deps...'


### PR DESCRIPTION
LTO is good for smaller binary size, but it was disabled due to long link time on macOS. So let's use ThinLTO on Windows and macOS, and use classic LTO on Linux.